### PR TITLE
gpt-3.5 と gpt-4 での sig:refine の結果を比較する

### DIFF
--- a/sig/rbs_goose.rbs
+++ b/sig/rbs_goose.rbs
@@ -1,9 +1,17 @@
 module RbsGoose
   VERSION: "0.1.0"
-  self.@configuration: RbsGoose::Configuration
+
+  self.@configuration: RbsGoose::Configuration?
+
   extend Forwardable
-  def self.configure: () { () -> untyped } -> untyped
-  def self.reset_configuration: () -> untyped
-  def self.run: (?code_dir: ::String, ?sig_dir: ::String, ?base_path: untyped) -> untyped
-  attr_reader self.configuration: RbsGoose::Configuration
+
+  def self.configure: () { () -> void } -> void
+
+  def self.reset_configuration: () -> void
+
+  def self.run: (?code_dir: ::String, ?sig_dir: ::String, ?base_path: String) -> void
+
+  attr_reader self.configuration: RbsGoose::Configuration?
+
+  def_delegators :self.configuration, :llm, :instruction, :example_groups
 end

--- a/sig/rbs_goose/configuration.rbs
+++ b/sig/rbs_goose/configuration.rbs
@@ -1,14 +1,14 @@
 class RbsGoose::Configuration
   @llm: Langchain::LLM::OpenAI
   @template: RbsGoose::Templates::DefaultTemplate
-  def initialize: () ?{ () -> untyped } -> void
+  def initialize: () ?{ () -> void } -> void
   attr_accessor llm: Langchain::LLM::OpenAI
   attr_accessor instruction: String
-  attr_accessor example_groups: Array[untyped]
-  attr_accessor template_class: RbsGoose::Templates::DefaultTemplate
-  def use_open_ai: (String open_ai_access_token, ?default_options: ::Hash[untyped, untyped]) -> untyped
+  attr_accessor example_groups: Array[RbsGoose::IO::ExampleGroup]
+  attr_accessor template_class: singleton(RbsGoose::Templates::DefaultTemplate)
+  def use_open_ai: (String open_ai_access_token, ?default_options: ::Hash[Symbol | String, untyped]) -> Langchain::LLM::OpenAI
   def template: () -> RbsGoose::Templates::DefaultTemplate
-  private def default_template_class: () -> RbsGoose::Templates::DefaultTemplate
+  private def default_template_class: () -> singleton(RbsGoose::Templates::DefaultTemplate)
   private def default_instruction: () -> String
-  private def default_example_groups: () -> Array[untyped]
+  private def default_example_groups: () -> ::Array[RbsGoose::IO::ExampleGroup]
 end

--- a/sig/rbs_goose/io/example.rbs
+++ b/sig/rbs_goose/io/example.rbs
@@ -1,7 +1,7 @@
 class RbsGoose::IO::Example
   @typed_ruby: RbsGoose::IO::TypedRuby
   @refined_rbs: RbsGoose::IO::File
-  def self.from_path: (ruby_path: String, rbs_path: String, refined_rbs_dir: String, base_path: untyped) -> RbsGoose::IO::Example
+  def self.from_path: (ruby_path: String, rbs_path: String, refined_rbs_dir: String, base_path: String) -> RbsGoose::IO::Example
   def initialize: (typed_ruby: RbsGoose::IO::TypedRuby, refined_rbs: RbsGoose::IO::File) -> void
   def to_h: () -> { typed_ruby: RbsGoose::IO::TypedRuby, refined_rbs: RbsGoose::IO::File }
   attr_reader typed_ruby: RbsGoose::IO::TypedRuby

--- a/sig/rbs_goose/io/example_group.rbs
+++ b/sig/rbs_goose/io/example_group.rbs
@@ -1,8 +1,8 @@
 class RbsGoose::IO::ExampleGroup < ::Array[RbsGoose::IO::Example]
-  self.@default_examples: { untyped => Array[RbsGoose::IO::Example] }
-  def self.load_from: (untyped base_path, ?code_dir: ::String, ?sig_dir: ::String, ?refined_dir: ::String) -> RbsGoose::IO::ExampleGroup
-  def self.default_examples: () -> { untyped => Array[RbsGoose::IO::Example] }
-  private def self.to_rbs_path: (String, String) -> String
+  self.@default_examples: ::Hash[Symbol, RbsGoose::IO::ExampleGroup]
+  def self.load_from: (base_path: String, ?code_dir: ::String, ?sig_dir: ::String, ?refined_dir: ::String) -> RbsGoose::IO::ExampleGroup
+  def self.default_examples: () -> ::Hash[Symbol, RbsGoose::IO::ExampleGroup]
+  private def self.to_rbs_path: (path: String, sig_dir: String) -> String
   def to_target_group: () -> RbsGoose::IO::TargetGroup
-  def to_refined_rbs_list: () -> Array[RbsGoose::IO::File]
+  def to_refined_rbs_list: () -> ::Array[RbsGoose::IO::File]
 end

--- a/sig/rbs_goose/io/file.rbs
+++ b/sig/rbs_goose/io/file.rbs
@@ -1,19 +1,19 @@
 class RbsGoose::IO::File
   @path: String
-  @base_path: untyped
+  @base_path: String?
   @content: String
   @type: Symbol
   MARKDOWN_REGEXP: ::Regexp
-  def self.from_markdown: (String) -> RbsGoose::IO::File
-  def initialize: (path: String, ?content: String, ?base_path: untyped) -> void
-  def load_content: () -> String
+  def self.from_markdown: (String markdown) -> RbsGoose::IO::File
+  def initialize: (path: String, ?content: String?, ?base_path: String?) -> void
+  def load_content: () -> void
   def absolute_path: () -> String
   def type: () -> Symbol
   def to_s: () -> String
-  def content=: (String) -> String
-  def write: () -> untyped
-  def ==: (untyped) -> untyped
+  def content=: (String content) -> String
+  def write: () -> void
+  def ==: (RbsGoose::IO::File other) -> bool
   attr_reader path: String
   attr_reader content: String
-  attr_reader base_path: untyped
+  attr_reader base_path: String?
 end

--- a/sig/rbs_goose/io/target_group.rbs
+++ b/sig/rbs_goose/io/target_group.rbs
@@ -1,3 +1,3 @@
 class RbsGoose::IO::TargetGroup < ::Array[RbsGoose::IO::TypedRuby]
-  def self.load_from: (untyped base_path, ?code_dir: ::String, ?sig_dir: ::String) -> RbsGoose::IO::TargetGroup
+  def self.load_from: (base_path: String, ?code_dir: ::String, ?sig_dir: ::String) -> RbsGoose::IO::TargetGroup
 end

--- a/sig/rbs_goose/io/typed_ruby.rbs
+++ b/sig/rbs_goose/io/typed_ruby.rbs
@@ -1,9 +1,9 @@
 class RbsGoose::IO::TypedRuby
   @ruby: RbsGoose::IO::File
-  @rbs: RbsGoose::IO::File
-  def self.from_path: (ruby_path: String, rbs_path: String, base_path: untyped) -> RbsGoose::IO::TypedRuby
-  def initialize: (ruby: RbsGoose::IO::File, rbs: RbsGoose::IO::File) -> void
-  def to_s: () -> (String | untyped)
+  @rbs: RbsGoose::IO::File?
+  def self.from_path: (ruby_path: String, rbs_path: String, base_path: String) -> RbsGoose::IO::TypedRuby
+  def initialize: (ruby: RbsGoose::IO::File, rbs: RbsGoose::IO::File?) -> void
+  def to_s: () -> String
   attr_reader ruby: RbsGoose::IO::File
-  attr_reader rbs: RbsGoose::IO::File
+  attr_reader rbs: RbsGoose::IO::File?
 end

--- a/sig/rbs_goose/templates/default_template.rbs
+++ b/sig/rbs_goose/templates/default_template.rbs
@@ -1,10 +1,10 @@
 class RbsGoose::Templates::DefaultTemplate
   @template: Langchain::Prompt::FewShotPromptTemplate
-  def initialize: (instruction: String, example_groups: Array[untyped]) -> void
-  def format: (Array[untyped]) -> untyped
-  def parse_result: (untyped) -> untyped
+  def initialize: (instruction: String, example_groups: Array[RbsGoose::IO::ExampleGroup]) -> void
+  def format: (Array[String] typed_ruby_list) -> String
+  def parse_result: (String result) -> Array[RbsGoose::IO::File]
   private attr_reader template: Langchain::Prompt::FewShotPromptTemplate
   private def example_prompt: () -> Langchain::Prompt::PromptTemplate
   private def input_template_string: () -> String
-  private def transform_example_group: (Array[untyped]) -> { typed_ruby_list: untyped, refined_rbs_list: untyped }
+  private def transform_example_group: (RbsGoose::IO::ExampleGroup example_group) -> { typed_ruby_list: String, refined_rbs_list: String }
 end

--- a/sig/rbs_goose/type_inferrer.rbs
+++ b/sig/rbs_goose/type_inferrer.rbs
@@ -1,3 +1,3 @@
 class RbsGoose::TypeInferrer
-  def infer: (untyped) -> untyped
+  def infer: (RbsGoose::IO::TargetGroup target_group) -> Array[RbsGoose::IO::File]
 end


### PR DESCRIPTION
このPRは出力を比較するためのものなので、マージせずクローズする。

全体として、gpt-3.5よりgpt-4のほうが戻り値のvoidや配列内の型などを正確かつ詳細に推測している。一方で無理に推測したことで誤っている部分も見受けられる。
また本来順序引数のものをキーワード引数にしてしまう間違いが見られた。おそらく似た変数名を使っている文脈に引っ張られており、gpt-3.5よりgpt-4のほうが文脈による影響が大きいように見える。