### PR TITLE
rbs_syntax をexample_groupsにしたときの差分を確認

### DIFF
--- a/sig/rbs_goose.rbs
+++ b/sig/rbs_goose.rbs
@@ -8,7 +8,7 @@ module RbsGoose
 
   def self.reset_configuration: () -> untyped
 
-  def self.run: (?code_dir: String, ?sig_dir: String, ?base_path: untyped) -> untyped
+  def self.run: (?code_dir: ::String, ?sig_dir: ::String, ?base_path: untyped) -> untyped
 
   attr_reader self.configuration: RbsGoose::Configuration
 end

--- a/sig/rbs_goose/configuration.rbs
+++ b/sig/rbs_goose/configuration.rbs
@@ -13,9 +13,7 @@ class RbsGoose::Configuration
 
   def template: () -> untyped
 
-  private def default_template_class: () -> Templates::DefaultTemplate
-
+  private def default_template_class: () -> untyped
   private def default_instruction: () -> String
-
-  private def default_example_groups: () -> Array[untyped]
+  private def default_example_groups: () -> ::Array[untyped]
 end

--- a/sig/rbs_goose/io/example_group.rbs
+++ b/sig/rbs_goose/io/example_group.rbs
@@ -1,13 +1,13 @@
 class RbsGoose::IO::ExampleGroup < ::Array[RbsGoose::IO::Example]
-  self.@default_examples: ::Hash[Symbol, RbsGoose::IO::ExampleGroup]
+  self.@default_examples: ::Hash[untyped, untyped]
 
-  def self.load_from: (String base_path, ?code_dir: String, ?sig_dir: String, ?refined_dir: String) -> RbsGoose::IO::ExampleGroup
+  def self.load_from: (untyped base_path, ?code_dir: ::String, ?sig_dir: ::String, ?refined_dir: ::String) -> untyped
 
-  def self.default_examples: () -> ::Hash[Symbol, RbsGoose::IO::ExampleGroup]
+  def self.default_examples: () -> untyped
 
-  private def self.to_rbs_path: (String path, String sig_dir) -> String
+  private def self.to_rbs_path: (String path, String sig_dir) -> untyped
 
   def to_target_group: () -> RbsGoose::IO::TargetGroup
 
-  def to_refined_rbs_list: () -> Array[RbsGoose::IO::File]
+  def to_refined_rbs_list: () -> untyped
 end

--- a/sig/rbs_goose/io/file.rbs
+++ b/sig/rbs_goose/io/file.rbs
@@ -2,22 +2,22 @@ class RbsGoose::IO::File
   @path: String
   @base_path: String
   @content: String
-  @type: :ruby | :rbs
+  @type: Symbol
   MARKDOWN_REGEXP: ::Regexp
 
-  def self.from_markdown: (String markdown) -> RbsGoose::IO::File
+  def self.from_markdown: (String markdown) -> untyped
 
   def initialize: (path: String, ?content: String, ?base_path: String) -> void
 
-  def load_content: () -> String
+  def load_content: () -> untyped
 
-  def absolute_path: () -> String
+  def absolute_path: () -> untyped
 
-  def type: () -> :ruby | :rbs
+  def type: () -> Symbol
 
   def to_s: () -> String
 
-  def content=: (String content) -> String
+  def content=: (String content) -> untyped
 
   def write: () -> untyped
 

--- a/sig/rbs_goose/io/target_group.rbs
+++ b/sig/rbs_goose/io/target_group.rbs
@@ -1,3 +1,3 @@
 class RbsGoose::IO::TargetGroup < ::Array[RbsGoose::IO::TypedRuby]
-  def self.load_from: (String base_path, ?code_dir: String, ?sig_dir: String) -> RbsGoose::IO::TargetGroup
+  def self.load_from: (untyped base_path, ?code_dir: ::String, ?sig_dir: ::String) -> untyped
 end

--- a/sig/rbs_goose/io/typed_ruby.rbs
+++ b/sig/rbs_goose/io/typed_ruby.rbs
@@ -2,7 +2,7 @@ class RbsGoose::IO::TypedRuby
   @ruby: RbsGoose::IO::File
   @rbs: RbsGoose::IO::File
 
-  def self.from_path: (ruby_path: String, rbs_path: String, base_path: String) -> RbsGoose::IO::TypedRuby
+  def self.from_path: (ruby_path: String, rbs_path: String, base_path: String) -> untyped
 
   def initialize: (ruby: RbsGoose::IO::File, rbs: RbsGoose::IO::File) -> void
 


### PR DESCRIPTION
example_groupsにrbs_exampleではなくrbs_syntaxを指定したときにどの程度変化するかを確認するためのPR。
マージせずにクローズする。

いずれも、sig以下が空の状態から `rbs sig:prototype sig:refine` を実行した結果を比較している。