### PR TITLE
llmのリクエストタイムアウトのデフォルトを10分に延長

### DIFF
--- a/lib/rbs_goose/configuration.rb
+++ b/lib/rbs_goose/configuration.rb
@@ -25,10 +25,14 @@ module RbsGoose
 
     attr_accessor :llm, :infer_template, :fix_error_template
 
-    def use_open_ai(open_ai_access_token, model_name: 'gpt-3.5-turbo-1106', mode: :chat, default_options: {})
+    def use_open_ai( # rubocop:disable Metrics/MethodLength
+      open_ai_access_token, model_name: 'gpt-3.5-turbo-1106', mode: :chat,
+      llm_options: {}, default_options: {}
+    )
       @llm = LLMConfig.new(
         client: ::Langchain::LLM::OpenAI.new(
           api_key: open_ai_access_token,
+          llm_options: { request_timeout: 600 }.merge(llm_options),
           default_options: {
             completion_model_name: model_name,
             chat_completion_model_name: model_name

--- a/spec/rbs_goose/configuration_spec.rb
+++ b/spec/rbs_goose/configuration_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe RbsGoose::Configuration do
           completion_model_name: 'dummy_model',
           chat_completion_model_name: 'dummy_model',
           temperature: 0.8
-        }
+        },
+        llm_options: { request_timeout: 600 }
       )
     end
   end


### PR DESCRIPTION
長い文字列を入れることになり、gpt-4-turboだと2分では出力が終わらないことが多いため、
デフォルトタイムアウトを長めにする