### PR TITLE
chore: 依存関係更新のクールダウン期間を1週間に設定

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "labels": [
     "dependencies"
   ],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "groupName": "rubocop",


### PR DESCRIPTION
## 概要

Renovateの依存関係更新設定にクールダウン期間を追加しました。

## 変更内容

- `renovate.json`にて`minimumReleaseAge`を7日間に設定
- 新しいパッケージバージョンがリリースされてから1週間経過後に更新が提案されるようになります

## 効果

- パッケージリリース直後の不安定なバージョンでの更新を回避
- より成熟したバージョンを使用することで、プロジェクトの安定性向上
- セキュリティ修正などの緊急度の高い更新は引き続き即座に適用されます

🤖 Generated with [Claude Code](https://claude.ai/code)